### PR TITLE
opti: cache revocation nonce

### DIFF
--- a/contracts/core/base/BaseOpenfortAccount.sol
+++ b/contracts/core/base/BaseOpenfortAccount.sol
@@ -340,15 +340,17 @@ abstract contract BaseOpenfortAccount is
         address[] calldata _whitelist
     ) external virtual {
         _requireFromOwner();
+
         require(_validUntil > block.timestamp, "Cannot register an expired session key");
         require(_validAfter < _validUntil, "_validAfter must be lower than _validUntil");
         require(sessionKeys[_key].validUntil == 0, "SessionKey already registered");
         require(_whitelist.length < 11, "Whitelist too big");
+
         uint256 i;
+        uint256 revocationNonce = sessionKeys[_key].revocationNonce;
 
         for (i; i < _whitelist.length;) {
-            // populate first whitelist entry - revocationNonce is 0
-            sessionKeys[_key].whitelist[sessionKeys[_key].revocationNonce][_whitelist[i]] = true;
+            sessionKeys[_key].whitelist[revocationNonce][_whitelist[i]] = true;
             unchecked {
                 ++i;
             }
@@ -365,10 +367,12 @@ abstract contract BaseOpenfortAccount is
                 sessionKeys[_key].masterSessionKey = false;
             }
         }
+
         sessionKeys[_key].validAfter = _validAfter;
         sessionKeys[_key].validUntil = _validUntil;
         sessionKeys[_key].limit = _limit;
         sessionKeys[_key].registrarAddress = owner();
+
         emit SessionKeyRegistered(_key);
     }
 


### PR DESCRIPTION
Register A session Key with two whitelist:

without caching revocation nonce:
https://explorer.sophon.xyz/tx/0x837623fbf99fe5c3e42bcc6d43d5321c9b8e60f4fba5cf6322deef90c04a39d5
156442 gas

with caching:
 https://explorer.sophon.xyz/tx/0x94c3c7b6471e89362ca63f60f695b8be3ed145703a8c2381ed473418daa2cd52>>> 125533 gas

>>> 30909 gas saved